### PR TITLE
Add basic ctext API crawler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+texts/
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # ctext.org_-crawler
+
+A minimal crawler for [ctext.org](https://ctext.org/) using its API.
+
+```bash
+python crawler.py --output texts --delay 1.0 --root zhs
+```
+
+The script recursively retrieves entries starting from the given root node
+(`zhs` for Chinese) and writes each text to a file under the specified
+output directory.

--- a/crawler.py
+++ b/crawler.py
@@ -1,0 +1,77 @@
+import argparse
+import json
+import time
+from pathlib import Path
+from urllib import error, request
+
+BASE_URL = "https://ctext.org/tools/api"
+
+
+def _sanitize(name: str) -> str:
+    """Return a filesystem-friendly representation of *name*.
+
+    Keeps alphanumeric characters, spaces, dashes and underscores and
+    strips anything else. The result is also trimmed.
+    """
+    return "".join(c for c in name if c.isalnum() or c in " -_").strip()
+
+
+def fetch_node(node: str, language: str) -> dict:
+    """Fetch *node* from the ctext API and return the parsed JSON."""
+    url = f"{BASE_URL}/{language}/{node.lstrip('/')}"
+    req = request.Request(url, headers={"User-Agent": "ctext-crawler"})
+    with request.urlopen(req) as resp:
+        return json.load(resp)
+
+
+def crawl(root: str = "zhs", out_dir: Path = Path("texts"), delay: float = 1.0) -> None:
+    """Recursively crawl the ctext API starting from *root*.
+
+    ``root`` is the starting node (usually ``"zhs"`` for Chinese texts).
+    ``out_dir`` is the directory where downloaded texts are stored.
+    ``delay`` specifies the delay (in seconds) between requests.
+    """
+    stack = [(root, out_dir)]
+    visited = set()
+
+    while stack:
+        node, path = stack.pop()
+        if node in visited:
+            continue
+        visited.add(node)
+        try:
+            data = fetch_node(node, "zhs")
+        except (error.HTTPError, error.URLError) as e:
+            print(f"Failed to fetch {node}: {e}")
+            continue
+        title = data.get("title") or node
+        content = data.get("text") or data.get("content")
+        if content:
+            filename = _sanitize(title) or f"{node}.txt"
+            target = path / f"{filename}.txt"
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(content, encoding="utf-8")
+        children = (
+            data.get("children")
+            or data.get("sub")
+            or data.get("sections")
+            or []
+        )
+        for child in children:
+            child_id = child.get("id") or child.get("path") or child.get("uri")
+            child_title = child.get("title", str(child_id))
+            stack.append((child_id, path / _sanitize(child_title)))
+        time.sleep(delay)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Crawl texts from ctext.org")
+    parser.add_argument("--output", default="texts", help="Output directory")
+    parser.add_argument("--delay", type=float, default=1.0, help="Delay between requests")
+    parser.add_argument("--root", default="zhs", help="Root node to start crawling")
+    args = parser.parse_args()
+    crawl(root=args.root, out_dir=Path(args.output), delay=args.delay)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement Python crawler that recursively downloads texts from ctext.org API using standard library
- document usage and parameters in README
- ignore generated output and bytecode in git

## Testing
- `python -m py_compile crawler.py`
- `python crawler.py --output texts --delay 0 --root zhs` *(fails: Tunnel connection failed: 403 Forbidden)*
- `python -m pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68993c404e7083248dc02326745c02a5